### PR TITLE
Replace generic plots with Plotly specific plots

### DIFF
--- a/Example/Example.cpp
+++ b/Example/Example.cpp
@@ -263,11 +263,8 @@ int main(){
   // Monitoring can plot how something changes with respect to time, but what
   // if you want a generic plot to appear on the web page? Use this class.
   /////////////////////////////////////////////////////////////////
-  Store plot_trace;
-
-  std::vector<float> plot_x(10);
+  std::vector<float> plot_x(5);
   for (size_t i = 0; i < plot_x.size(); ++i) plot_x[i] = i;
-  plot_trace.Set("x", plot_x);
 
   std::string plot_layout = "{"
     "\"title\":\"A random plot\","
@@ -365,13 +362,22 @@ int main(){
       //////////////////////////////////////////////////////////////////////////////////////////
       
       ////////////////////////////////////// plot /////////////////////////////////////////////
-      for (auto& y : plot_y) y = rand();
-      plot_trace.Set("y", plot_y);
+      {
+        std::vector<std::string> traces(2);
 
-      std::string json_trace;
-      plot_trace >> json_trace;
+        for (auto& y : plot_y) y = rand();
+        Store store;
+        store.Set("x", plot_x);
+        store.Set("y", plot_y);
+        store >> traces[0];
 
-      DAQ_inter.SendPlotlyPlot("test_plot", json_trace, plot_layout);
+        for (auto& y : plot_y) y = rand();
+        store.Set("x", plot_x);
+        store.Set("y", plot_y);
+        store >> traces[1];
+
+        DAQ_inter.SendPlotlyPlot("test_plot", traces, plot_layout);
+      };
       //////////////////////////////////////////////////////////////////////////////////////////
       
       ///////////////////////  using and getting slow control values /////////////// 

--- a/Example/Example.cpp
+++ b/Example/Example.cpp
@@ -309,6 +309,27 @@ int main(){
       DAQ_inter.sc_vars["Start"]->SetValue(false);  // important! reset the slow control value after use.
       
       DAQ_inter.sc_vars.AlertSend("new_event"); // example of sending alert to all DAQ devices
+
+      ////////////////////////////////////// plot /////////////////////////////////////////////
+      /// Each plot is stored in the database as a different version. We place
+      /// this example here to avoid sending a new plot each second.
+      {
+        std::vector<std::string> traces(2);
+
+        for (auto& y : plot_y) y = rand();
+        Store store;
+        store.Set("x", plot_x);
+        store.Set("y", plot_y);
+        store >> traces[0];
+
+        for (auto& y : plot_y) y = rand();
+        store.Set("x", plot_x);
+        store.Set("y", plot_y);
+        store >> traces[1];
+
+        DAQ_inter.SendPlotlyPlot("test_plot", traces, plot_layout);
+      };
+      //////////////////////////////////////////////////////////////////////////////////////////
       
     }
     last_started = started;
@@ -359,25 +380,6 @@ int main(){
       // send to the database
       DAQ_inter.SendMonitoringData(monitoring_json);
       
-      //////////////////////////////////////////////////////////////////////////////////////////
-      
-      ////////////////////////////////////// plot /////////////////////////////////////////////
-      {
-        std::vector<std::string> traces(2);
-
-        for (auto& y : plot_y) y = rand();
-        Store store;
-        store.Set("x", plot_x);
-        store.Set("y", plot_y);
-        store >> traces[0];
-
-        for (auto& y : plot_y) y = rand();
-        store.Set("x", plot_x);
-        store.Set("y", plot_y);
-        store >> traces[1];
-
-        DAQ_inter.SendPlotlyPlot("test_plot", traces, plot_layout);
-      };
       //////////////////////////////////////////////////////////////////////////////////////////
       
       ///////////////////////  using and getting slow control values /////////////// 

--- a/Example/Example.cpp
+++ b/Example/Example.cpp
@@ -259,20 +259,23 @@ int main(){
   
   /////////////////////////////////////////////////////////////////
 
-  //////////////////////////////// a generic plot /////////////////
+  //////////////////////////////// a Plotly plot /////////////////
   // Monitoring can plot how something changes with respect to time, but what
   // if you want a generic plot to appear on the web page? Use this class.
   /////////////////////////////////////////////////////////////////
-  Plot plot { "test_plot" };
-  plot.x.resize(10);
-  for (size_t i = 0; i < plot.x.size(); ++i) plot.x[i] = i;
-  plot.y.resize(plot.x.size());
-  plot.title = "A random plot";
-  plot.xlabel = "x";
-  plot.ylabel = "y";
-  // plot.info stores a generic JSON. It is not processed by ToolDAQ and can be used to attach extra information to a plot.
-  plot.info.Set("comment", "example plot"); // -> { "comment": "example plot" }
-  
+  Store plot_trace;
+
+  std::vector<float> plot_x(10);
+  for (size_t i = 0; i < plot_x.size(); ++i) plot_x[i] = i;
+  plot_trace.Set("x", plot_x);
+
+  std::string plot_layout = "{"
+    "\"title\":\"A random plot\","
+    "\"xaxis\":{\"title\":\"x\"},"
+    "\"yaxis\":{\"title\":\"y\"}"
+  "}";
+
+  std::vector<float> plot_y(plot_x.size()); // see below
   /////////////////////////// generic SQL query example //////////////////////
   
   std::string resp;
@@ -362,8 +365,13 @@ int main(){
       //////////////////////////////////////////////////////////////////////////////////////////
       
       ////////////////////////////////////// plot /////////////////////////////////////////////
-      for (auto& y : plot.y) y = rand();
-      DAQ_inter.SendPlot(plot);
+      for (auto& y : plot_y) y = rand();
+      plot_trace.Set("y", plot_y);
+
+      std::string json_trace;
+      plot_trace >> json_trace;
+
+      DAQ_inter.SendPlotlyPlot("test_plot", json_trace, plot_layout);
       //////////////////////////////////////////////////////////////////////////////////////////
       
       ///////////////////////  using and getting slow control values /////////////// 

--- a/include/DAQInterface.h
+++ b/include/DAQInterface.h
@@ -46,6 +46,7 @@ namespace ToolFramework {
     bool SendPersistentROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version=nullptr, const unsigned int timestamp=0, const unsigned int timeout=300);
     bool GetROOTplot(const std::string& plot_name, int& version, std::string& draw_option, std::string& json_data, std::string* timestamp=nullptr, const unsigned int timeout=300);
     bool SendPlotlyPlot(const std::string& name, const std::string& json_trace, const std::string& json_layout="{}", int* version=nullptr, unsigned int timestamp=0, unsigned int timeout=300);
+    bool SendPlotlyPlot(const std::string& name, const std::vector<std::string>& json_traces, const std::string& json_layout="{}", int* version=nullptr, unsigned int timestamp=0, unsigned int timeout=300);
     bool GetPlotlyPlot(const std::string& name, int& version, std::string& json_trace, std::string& json_layout, unsigned int* timestamp=nullptr, unsigned int timeout=300);
     
     SlowControlCollection* GetSlowControlCollection();

--- a/include/DAQInterface.h
+++ b/include/DAQInterface.h
@@ -45,8 +45,8 @@ namespace ToolFramework {
     bool SendTemporaryROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version=nullptr, const unsigned int timestamp=0);
     bool SendPersistentROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version=nullptr, const unsigned int timestamp=0, const unsigned int timeout=300);
     bool GetROOTplot(const std::string& plot_name, int& version, std::string& draw_option, std::string& json_data, std::string* timestamp=nullptr, const unsigned int timeout=300);
-    bool SendPlot(Plot& plot, unsigned timeout=300);
-    bool GetPlot(const std::string& name, Plot& plot, unsigned timeout=300);
+    bool SendPlotlyPlot(const std::string& name, const std::string& json_trace, const std::string& json_layout="{}", int* version=nullptr, unsigned int timestamp=0, unsigned int timeout=300);
+    bool GetPlotlyPlot(const std::string& name, int& version, std::string& json_trace, std::string& json_layout, unsigned int* timestamp=nullptr, unsigned int timeout=300);
     
     SlowControlCollection* GetSlowControlCollection();
     SlowControlElement* GetSlowControlVariable(std::string key);

--- a/src/DAQInterface.cpp
+++ b/src/DAQInterface.cpp
@@ -171,6 +171,10 @@ bool DAQInterface::SendPlotlyPlot(const std::string& name, const std::string& tr
   return m_services->SendPlotlyPlot(name, trace, layout, version, timestamp, timeout);
 }
 
+bool DAQInterface::SendPlotlyPlot(const std::string& name, const std::vector<std::string>& traces, const std::string& layout, int* version, unsigned int timestamp, unsigned int timeout) {
+  return m_services->SendPlotlyPlot(name, traces, layout, version, timestamp, timeout);
+}
+
 // ===========================================================================
 // Other functions
 // ---------------

--- a/src/DAQInterface.cpp
+++ b/src/DAQInterface.cpp
@@ -106,11 +106,9 @@ bool DAQInterface::GetROOTplot(const std::string& plot_name, int& version, std::
   
 }
 
-bool DAQInterface::GetPlot(const std::string& name, Plot& plot, unsigned timeout){
-  
-  
-  return m_services->GetPlot(name, plot, timeout);
-  
+bool DAQInterface::GetPlotlyPlot(const std::string& name, int& version, std::string& trace, std::string& layout, unsigned int* timestamp, unsigned int timeout) {
+
+  return m_services->GetPlotlyPlot(name, version, trace, layout, timestamp, timeout);
 }
 
 bool DAQInterface::SQLQuery(const std::string& database, const std::string& query, std::vector<std::string>& responses, const unsigned int timeout){
@@ -169,8 +167,8 @@ bool DAQInterface::SendTemporaryROOTplot(const std::string& plot_name, const std
   
 }
 
-bool DAQInterface::SendPlot(Plot& plot, unsigned timeout){
-  return m_services->SendPlot(plot, timeout);
+bool DAQInterface::SendPlotlyPlot(const std::string& name, const std::string& trace, const std::string& layout, int* version, unsigned int timestamp, unsigned int timeout) {
+  return m_services->SendPlotlyPlot(name, trace, layout, version, timestamp, timeout);
 }
 
 // ===========================================================================


### PR DESCRIPTION
Instead of storing a generic plot in the database, store two JSON objects --- trace and layout --- that are arguments to Plotly plotting functions.