### PR TITLE
Makefile: swap -lServiceDiscovery and -lDAQDataModelBase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ZMQInclude= -I $(Dependencies)/zeromq-4.0.7/include/
 BoostLib= -L $(Dependencies)/boost_1_66_0/install/lib -lboost_date_time -lboost_serialization -lboost_iostreams
 BoostInclude= -I $(Dependencies)/boost_1_66_0/install/include
 
-ToolDAQLib= -L $(Dependencies)/ToolDAQFramework/lib   -lDAQDataModelBase -lServiceDiscovery -lDAQStore
+ToolDAQLib= -L $(Dependencies)/ToolDAQFramework/lib   -lServiceDiscovery -lDAQDataModelBase -lDAQStore
 ToolDAQInclude= -I $(Dependencies)/ToolDAQFramework/include
 
 ToolFrameworkLib= -L $(Dependencies)/ToolFrameworkCore/lib -lStore -lDataModelBase


### PR DESCRIPTION
Fix `python3: symbol lookup error: /.../libServiceDiscovery.so: undefined symbol: _ZN13ToolFramework12DAQUtilitiesC1EPN3zmq9context_tE`