### PR TITLE
State and ChangeConfig wrapping

### DIFF
--- a/InterfaceConfig
+++ b/InterfaceConfig
@@ -1,16 +1,16 @@
 ############################ DAQ Interface ############################
 UUID b16a0186-c5df-474c-b880-9fc6c0670d7d   # unique identifier for client (must be valid uuid)
-UUID_path ./UUID			    # if no uuid is specified one is generated one first execution, saved at the path specified and reused
+UUID_path ./UUID                            # if no uuid is specified one is generated one first execution, saved at the path specified and reused
 device_name Example                         # name of devices
 sc_port 6001                                # local port to use for slow control
-zmq_io_threads 1			    # number of io threadws for zmwq context
+zmq_io_threads 1                            # number of io threadws for zmwq context
 
 
 ############################ Service discovery ########################
-service_discovery_address 239.192.1.1 	    # multicast address to use for service discovery
-service_discovery_port 5000           	    # port to use for service discovery braodcast
-service_publish_sec 5                 	    # heartbeat send period
-service_kick_sec 60                   	    # remove hosts with no heartbeat after given period
+service_discovery_address 239.192.1.1       # multicast address to use for service discovery
+service_discovery_port 5000                 # port to use for service discovery braodcast
+service_publish_sec 5                       # heartbeat send period
+service_kick_sec 60                         # remove hosts with no heartbeat after given period
 multicast_send_period_ms 5000               # batch send multicast messages with this period
 
 
@@ -21,7 +21,7 @@ alerts_receive 1                            # enable ability to receive global a
 alert_send_port 12244                       # local port to use for sending global alerts
 mon_merge_period_ms 5000                    # only send the first monitoring message with a given device and subject once per this period
 alarm_cooldown_ms 1000                      # only send the first alarm with a given device and message once per this period
-#config_name  ?????	  		    # if your configuration is stored in the db not under device name	      
+#config_name  ?????                         # if your configuration is stored in the db not under device name
 
 
 ########################### Services Backend #########################

--- a/include/DAQInterface.h
+++ b/include/DAQInterface.h
@@ -67,9 +67,16 @@ namespace ToolFramework {
     bool AlertSubscribe(std::string alert, std::function<bool(const char*, const char*)> function);
     bool AlertSend(std::string alert, std::string payload);
     
+    bool SetChangeConfigFunc(std::function<bool(std::string)>);
+    
     std::string PrintSlowControlVariables();
     std::string GetDeviceName();
     void SetVerbose(bool in);
+    
+    void SetActive(bool active);
+    void SetError(bool error);
+    void SetWarning(bool warn);
+    void ClearState();
     
     template<typename T> T GetSlowControlValue(std::string name){
       return sc_vars[name]->GetValue<T>();

--- a/src/DAQInterface.cpp
+++ b/src/DAQInterface.cpp
@@ -1,96 +1,100 @@
 #include <DAQInterface.h>
+#include <cstdio>
 
 using namespace ToolFramework;
 
 DAQInterface::DAQInterface(std::string configuration_file, zmq::context_t* context){
-
+  
   if(!vars.Initialise(configuration_file)){
     std::clog<<"Error invalid configuration file given to DAQ Interface: "<<configuration_file<<std::endl;
   }
   
   if(!vars.Get("device_name",m_name)) m_name = "unnamed";
   vars.Set("service_name",m_name);
-
-#include <cstdio>
-
-boost::uuids::uuid m_UUID;
-std::string s_uuid;
-
- if(vars.Get("UUID", s_uuid)){
-   m_UUID = boost::uuids::string_generator{}(s_uuid);
- }
- else{
-   std::string uuid_path;
-   if(vars.Get("UUID_path", uuid_path)){
-     FILE* fp = fopen(uuid_path.c_str(), "rb");
-     
-     if (fp){
-       // UUID file exists; read it.
-       if (fread(&m_UUID, sizeof(m_UUID), 1, fp) != 1){
-	 // Read failed; generate a new UUID.
-	 m_UUID = boost::uuids::random_generator()();
-       }
-       
-       fclose(fp);
-     }
-     else{
-       // UUID file doesn't exist; generate and save one.
+  
+  boost::uuids::uuid m_UUID;
+  std::string s_uuid;
+  
+  if(vars.Get("UUID", s_uuid)){
+    m_UUID = boost::uuids::string_generator{}(s_uuid);
+    
+  } else {
+    
+    std::string uuid_path;
+    if(vars.Get("UUID_path", uuid_path)){
+      
+      FILE* fp = fopen(uuid_path.c_str(), "rb");
+      
+      if(fp){
+        
+        // UUID file exists; read it.
+        if (fread(&m_UUID, sizeof(m_UUID), 1, fp) != 1){
+          // Read failed; generate a new UUID.
+          m_UUID = boost::uuids::random_generator()();
+        }
+        
+        fclose(fp);
+        
+      } else {
+        // UUID file doesn't exist; generate and save one.
+        m_UUID = boost::uuids::random_generator()();
+        
+        fp = fopen(uuid_path.c_str(), "wb");
+        if(fp){
+          fwrite(&m_UUID, sizeof(m_UUID), 1, fp);
+          fclose(fp);
+        }
+      }
+      
+    } else {
+       // No UUID path specified; just generate one.
        m_UUID = boost::uuids::random_generator()();
-       
-       fp = fopen(uuid_path.c_str(), "wb");
-       if (fp){
-	 fwrite(&m_UUID, sizeof(m_UUID), 1, fp);
-	 fclose(fp);
-       }
-     }
-   }
-   else {
-     // No UUID path specified; just generate one.
-     m_UUID = boost::uuids::random_generator()();
-   }
- }
- 
- 
- int pubsec = 5;
- int kicksec = 60;
- 
- vars.Get("service_publish_sec", pubsec);
- vars.Get("service_kick_sec", kicksec);
- 
- bool send = (pubsec>=0);
- bool receive = (kicksec>=0);
- int remote_port = 60000;
- 
- vars.Get("sc_port", remote_port);
- 
- std::vector<std::string> mc_addresses;  
- std::vector<int> mc_ports;
- 
- if(!vars.Get("service_discovery_address",mc_addresses)){
-   std::string tmp_address="";
-   if(vars.Get("service_discovery_address",tmp_address)) mc_addresses.emplace_back(tmp_address);
-   else  mc_addresses.emplace_back("239.192.1.1");
- }
- if(!vars.Get("service_discovery_port",mc_ports)){
-   int tmp_port=0;
-   if(vars.Get("service_discovery_port",tmp_port)) mc_ports.emplace_back(tmp_port);
-   else mc_ports.emplace_back(5000);
- }                  
- 
- if(context==0){
-   int iothreads = 1;
-   vars.Get("zmq_io_threads",iothreads);
-   
-   m_context = new zmq::context_t(iothreads);
- }
- else m_context = context;
- 
- mp_SD = new ServiceDiscovery(send, receive, remote_port, mc_addresses, mc_ports , m_context,m_UUID, m_name, pubsec, kicksec);
- 
- 
- m_services= new Services();
- m_services->Init(vars, m_context, &sc_vars, true);
- 
+    }
+  }
+  
+  
+  int pubsec = 5;
+  int kicksec = 60;
+  
+  vars.Get("service_publish_sec", pubsec);
+  vars.Get("service_kick_sec", kicksec);
+  
+  bool send = (pubsec>=0);
+  bool receive = (kicksec>=0);
+  int remote_port = 60000;
+  
+  vars.Get("sc_port", remote_port);
+  
+  std::vector<std::string> mc_addresses;
+  std::vector<int> mc_ports;
+  
+  if(!vars.Get("service_discovery_address",mc_addresses)){
+    std::string tmp_address="";
+    if(vars.Get("service_discovery_address",tmp_address)) mc_addresses.emplace_back(tmp_address);
+    else  mc_addresses.emplace_back("239.192.1.1");
+  }
+  
+  if(!vars.Get("service_discovery_port",mc_ports)){
+    int tmp_port=0;
+    if(vars.Get("service_discovery_port",tmp_port)) mc_ports.emplace_back(tmp_port);
+    else mc_ports.emplace_back(5000);
+  }
+  
+  if(context==0){
+    int iothreads = 1;
+    vars.Get("zmq_io_threads",iothreads);
+    
+    m_context = new zmq::context_t(iothreads);
+  } else {
+     m_context = context;
+  }
+  
+  mp_SD = new ServiceDiscovery(send, receive, remote_port, mc_addresses, mc_ports , m_context,m_UUID, m_name, pubsec,  kicksec);
+  
+  
+  m_services= new Services();
+  m_services->Init(vars, m_context, &sc_vars, true);
+  
 }
 
 DAQInterface::~DAQInterface(){
@@ -105,12 +109,12 @@ DAQInterface::~DAQInterface(){
 }
 
 void DAQInterface::SetVerbose(bool in){
-	m_services->SetVerbose(in);
-	return;
+  m_services->SetVerbose(in);
+  return;
 }
 
 bool DAQInterface::Ready(int timeout_ms){
-	return m_services->Ready(timeout_ms);
+  return m_services->Ready(timeout_ms);
 }
 
 // ===========================================================================
@@ -277,7 +281,8 @@ SlowControlElement* DAQInterface::GetSlowControlVariable(std::string key){
   
 }
 
-bool DAQInterface::AddSlowControlVariable(std::string name, SlowControlElementType type, std::function<std::string(const char*)> change_function, std::function<std::string(const char*)> read_function){
+// SCFunction defined in SlowControlElement.h: std::function<std::string(const char*)>
+bool DAQInterface::AddSlowControlVariable(std::string name, SlowControlElementType type, SCFunction change_function, SCFunction read_function){
   
   return sc_vars.Add(name, type, change_function, read_function);
   
@@ -295,7 +300,8 @@ void DAQInterface::ClearSlowControlVariables(){
   
 }
 
-bool DAQInterface::AlertSubscribe(std::string alert, std::function<bool(const char*, const char*)> function){
+// AlertFunction defined in SlowControlCollection.h: std::function<bool(const char*, const char*)>
+bool DAQInterface::AlertSubscribe(std::string alert, AlertFunction function){
   
   return sc_vars.AlertSubscribe(alert, function);
   
@@ -327,5 +333,84 @@ std::string DAQInterface::GetLocalConfig(){
 bool DAQInterface::SetLocalConfig(std::string json){
   
   return m_services->SetLocalConfig(json);
+  
+}
+
+void DAQInterface::SetActive(bool active){
+  return sc_vars.SetActive(active);
+}
+
+void DAQInterface::SetError(bool error){
+  return sc_vars.SetError(error);
+}
+
+void DAQInterface::SetWarning(bool warn){
+  return sc_vars.SetWarning(warn);
+}
+
+void DAQInterface::ClearState(){
+  return sc_vars.ClearState();
+}
+
+bool DAQInterface::SetChangeConfigFunc(std::function<bool(std::string)> func){
+  
+  // we'll make three things that call this function:
+  // 1. subscribe to alerts.
+  // 2. a BUTTON slow control.
+  // 3. a COMMAND slow control.
+  // However, the signatures here are different:
+  // Alert callbacks receive an alert name and payload, and return a bool.
+  // Slow controls receive a control name, and return a string.
+  // COMMANDs have an associated string variable in the SlowControlCollection, but buttons don't.
+  // The idea here is the Alert and BUTTON will retrieve their configuration from the LocalConfig member of
+  // the SlowControlCollection, while the COMMAND will get its configuration from the slow control variable.
+  // To align these we accept something whihc is none of these, and pass it whatever's appropriate.
+  bool allgood=true;
+  
+  // 1.
+  allgood = AlertSubscribe("ChangeConfig", [this, func](const char*, const char*) -> bool{
+    return func(m_services->GetLocalConfig());
+  });
+  
+  // 2.
+  allgood = allgood &&
+  sc_vars.Add("ChangeConfig",
+              BUTTON,
+              [this, func](const char*) -> std::string {
+                sc_vars["Config"]->SetValue((int)ConfigState::ChangeStart);
+                bool ok = func(m_services->GetLocalConfig());
+                if(!ok) sc_vars["State"]->SetValue((int)State::Warning);
+                int new_state = ok ? (int)ConfigState::ChangeEnd : (int)ConfigState::ChangeFail;
+                sc_vars["Config"]->SetValue(new_state);
+                sc_vars["NewConfig"]->SetValue(0);
+                // FIXME dcsdue to a present bug in the webserver, if we leave a JSON value
+                // in a slow control, it will break the display of slow controls. :(
+                sc_vars["Config"]->SetValue<std::string>("");
+                return (ok ? "OK" : "Error");
+              },
+              0,
+              false); // this version will not be locked during non-testing runs,
+                      // since it only allows loading configurations in line with the current run type.
+  
+  // 3.
+  allgood = allgood &&
+  sc_vars.Add("ChangeToConfig",
+              COMMAND,
+              [this, func](const char* name) -> std::string {
+                sc_vars["Config"]->SetValue((int)ConfigState::ChangeStart);
+                bool ok = func(sc_vars[name]->GetValue<std::string>());
+                int new_state = ok ? (int)ConfigState::ChangeEnd : (int)ConfigState::ChangeFail;
+                sc_vars["Config"]->SetValue(new_state);
+                if(!ok) sc_vars["State"]->SetValue((int)State::Warning);
+                // FIXME due to a present bug in the webserver, if we leave a JSON value
+                // in a slow control, it will break the display of slow controls. :(
+                sc_vars["Config"]->SetValue<std::string>("");
+                return (ok ? "OK" : "Error");
+              },
+              0,
+              true); // this version will be locked during non-testing runs,
+                     // since it allows loading arbitrary configurations
+  
+  return allgood;
   
 }


### PR DESCRIPTION
* Add SetActive, SetWarning, SetError, ClearState state control functions to wrap those of SlowControlCollection.
* Add SetChangeConfigFunc method, which: subscribes to ChangeConfig alert, also makes a ChangeConfig button to trigger the same, and makes a lockable ChangeToConfig COMMAND slow control that takes a new JSON configuration and passes it to ChangeConfig.